### PR TITLE
multiprocess fix - default to 'fork' method

### DIFF
--- a/vbmc4vsphere/manager.py
+++ b/vbmc4vsphere/manager.py
@@ -32,6 +32,8 @@ DEFAULT_SECTION = "VirtualBMC"
 
 CONF = vbmc_config.get_config()
 
+# Always default to 'fork' multiprocessing
+multiprocessing.set_start_method("fork")
 
 class VirtualBMCManager(object):
 


### PR DESCRIPTION
Newer versions of Python (3.8+) on macOS default multiprocessing to utilize the 'spawn' method, which results in a "Cannot be pickled" error when attempting to start. This sets method to always 'fork'.
Fixes issue #2 