### PR TITLE
[Improvement] UUID lookup method for VM search.

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,7 @@ python -m pip install vbmc4vsphere
   | viserver_password | ***                 |
   | viserver_username | vsbmc@vsphere.local |
   | vm_name           | lab-vesxi01         |
+  | vm_uuid           | None                |
   +-------------------+---------------------+
   ```
 
@@ -289,6 +290,23 @@ password = password
 address = ::
 port = 6230
 vm_name = lab-vesxi01
+viserver = 192.168.0.1
+viserver_username = vsbmc@vsphere.local
+viserver_password = my-secure-password
+active = True
+```
+
+To speedup VM lookup on large deployments you can specify vm uuid in the `config` file.
+
+```bash
+$ cat ~/.vsbmc/lab-vesxi01/config
+[VirtualBMC]
+username = admin
+password = password
+address = ::
+port = 6230
+vm_name = lab-vesxi01
+vm_uuid = 903a0dfb-68d1-4d2e-9674-10e353a733ca
 viserver = 192.168.0.1
 viserver_username = vsbmc@vsphere.local
 viserver_password = my-secure-password

--- a/vbmc4vsphere/exception.py
+++ b/vbmc4vsphere/exception.py
@@ -31,6 +31,10 @@ class VMNotFound(VirtualBMCError):
     message = "No VN with matching name %(vm)s was found"
 
 
+class VMNotFoundByUUID(VirtualBMCError):
+    message = "No VN with matching UUID %(uuid)s was found"
+
+
 class VIServerConnectionOpenError(VirtualBMCError):
     message = (
         'Fail to establish a connection with VI Server "%(vi)s". ' "Error: %(error)s"

--- a/vbmc4vsphere/manager.py
+++ b/vbmc4vsphere/manager.py
@@ -45,6 +45,7 @@ class VirtualBMCManager(object):
         "port",
         "fakemac",
         "vm_name",
+        "vm_uuid",
         "viserver",
         "viserver_username",
         "viserver_password",

--- a/vbmc4vsphere/utils.py
+++ b/vbmc4vsphere/utils.py
@@ -65,6 +65,20 @@ def get_obj_by_name(conn, root, vim_type, value):
     return objs
 
 
+def get_viserver_vm_by_uuid(conn, uuid):
+    try:
+        search_index = conn.content.searchIndex
+        vm = search_index.FindByUuid(None, uuid, True)
+
+        if vm:
+            return vm
+        else:
+            raise Exception
+
+    except Exception:
+        raise exception.VMNotFoundByUUID(uuid=uuid)
+
+
 def get_viserver_vm(conn, vm):
     try:
         vms = get_obj_by_name(conn, conn.content.rootFolder, [vim.VirtualMachine], vm)


### PR DESCRIPTION
One can specify VM uuid to speed up lookup on a large deployments.
If vm_uuid is ommited, general VM lookup by name should happen.

vm_name parameter is still required.